### PR TITLE
Updated notes on volumes, python and tutorials.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -193,7 +193,8 @@ docker stop panoptes_docker && docker rm panoptes_docker
 
 ## Configuration
 
-Panoptes is run as a python module, so the relevant code is under site-packages in the venv (`/home/panoptes_v/lib/site-packages`)
+Panoptes is run as a python module, so the relevant code is under site-packages in the 
+venv (`/home/panoptes_v/lib/site-packages`).  You can `activate` this environment from within the docker container.
 
 ### Runtime
 
@@ -225,7 +226,8 @@ docker run -d \
 During the build of the container, the plugins from each subdirectory of `/resource/panoptes/plugins` are copied into 
 the container, so this is a good entry point into the structure.
 
-See the [Panoptes Plugin](https://github.com/yahoo/panoptes/blob/master/docs/Concepts.md#plugins) page for details
+See the [Panoptes Plugin](https://github.com/yahoo/panoptes/blob/master/docs/Concepts.md#plugins) page for details.
+You'll also find instructions on building plugins at the [Plugin Guide](https://getpanoptes.io/docs/panoptes-reference/plugin-guide)
 
 ## Additional Resources
 

--- a/resources/daemontools/redis-server.run
+++ b/resources/daemontools/redis-server.run
@@ -3,7 +3,6 @@
 #
 # Licensed under the terms of the Apache 2.0 license. See LICENSE file in https://github.com/yahoo/panoptes_docker/LICENSE for terms.
 
-exec echo 'SET panoptes:secrets:snmp_community_string:{$SNMP_SITE} {$SNMP_COMM_STRING}' | redis-cli
 exec setuidgid redis sh -c '
   exec /usr/bin/redis-server /etc/redis/redis.conf
 '

--- a/resources/panoptes/readme.md
+++ b/resources/panoptes/readme.md
@@ -4,3 +4,68 @@ Panoptes configuration files
 All files from the conf directory have been drawn and modified from
 https://github.com/yahoo/panoptes/tree/master/examples/conf
 
+# Building a local Python environment
+
+Useful for IDEs that don't build environments.  Requires that python3 is installed, along with python3-venv.
+
+```bash
+python3 -m venv ./panoptes_v && \
+source ./panoptes_v/bin/activate && \
+pip3 install wheel && \
+pip3 install yahoo-panoptes
+```
+
+Ignore the warnings about Kombu.
+
+# Mounting directories from the Host to the Container
+
+## localhost.json override
+
+You can override the default [localhost.json](resources/panoptes/localhost.json) by supplying one externally and adding 
+a flag during the container runtime. The `-v` join effectively overlays the *default* localhost.json built into the 
+container.  This example uses a localhost.json at `/dev/panoptes/conf` on the host.
+
+Use `-v <source_location>:/home/panoptes/conf/localhost.json` as a template.
+
+```bash
+docker run -d \
+    --sysctl net.core.somaxconn=511 \
+    --name="panoptes_docker" \
+    --shm-size=2G \
+    -v /dev/panoptes/conf/localhost.json:/home/panoptes/conf/localhost.json \
+    -p 127.0.0.1:8080:3000/tcp \
+    panoptes_docker
+```
+
+## Mounting external plugin directories.
+
+The same process can be applied to mount plugin directories from the host to the container.
+
+For example, we want to test our tutorial plugin `/dev/panoptes/plugin/test/tutorial_polling_plugin.py` against the 
+running container.  Because it's a polling plugin, we'll want it to be mounted in the path for the polling plugins, or 
+`/home/panoptes_v/lib/python3.6/site-packages/yahoo_panoptes/plugins/polling/`.  This makes it available to the python 
+venv.
+
+```bash
+docker run -d \
+    --sysctl net.core.somaxconn=511 \
+    --name="panoptes_docker" \
+    --shm-size=2G \
+    -v /dev/panoptes/plugin/test:/home/panoptes_v/lib/python3.6/site-packages/yahoo_panoptes/plugins/polling/test \
+    -p 127.0.0.1:8080:3000/tcp \
+    panoptes_docker
+```
+
+You can mount multiple volumes to test multiple plugins, or change the device data.  For example, combining the 
+localhost.json mount above, we can create a development environment;
+
+```bash
+docker run -d \
+    --sysctl net.core.somaxconn=511 \
+    --name="panoptes_docker" \
+    --shm-size=2G \
+    -v /dev/panoptes/plugin/test:/home/panoptes_v/lib/python3.6/site-packages/yahoo_panoptes/plugins/polling/test \
+    -v /dev/panoptes/conf/localhost.json:/home/panoptes/conf/localhost.json \
+    -p 127.0.0.1:8080:3000/tcp \
+    panoptes_docker
+```


### PR DESCRIPTION
Added some notes on volumes and building a python venv on the host.
Removed the CLI command from the deamon run as it was a useful as a chocolate teapot.
Updated a link on locating the plugin tutorials.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
