### PR TITLE
Updating the documentation ro remove the Redis population step.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,17 +108,7 @@ docker run -d \
     panoptes_docker
 ```
 
-There is a five minute delay until the first metrics will show up.  Due to an issue getting the snmp_community strings 
-into the container's redis, we do need you to run a script on the running container;
-
-```bash
-docker exec -it panoptes_docker bash
-/etc/redis/populate_redis.sh
-exit
-```
-
-This effectively writes the environment variables SNMP_SITE and SNMP_COMM_STRING into Redis.  These default to `local` 
-and `public` respectively, and can be overriden in the `docker run` command by supplying `-e <VAR> value`. 
+There is a five minute delay until the first metrics will show up.
 
 ### Visualize with Grafana
 

--- a/docker_quickstart.md
+++ b/docker_quickstart.md
@@ -42,15 +42,6 @@ docker run -d \
     panoptes_docker
 ```
 
-We had some problems getting the community strings into redis, so you will need to run the script 
-`/etc/redis/populate_redis.sh` inside the container.  We'll fix this inconvenience at some point.
-
-```bash
-docker exec -it panoptes_docker bash
-/etc/redis/populate_redis.sh
-exit
-```
-
 This will populate redis with the SNMP_SITE and SNMP_COMM_STRING environment variables.
 
 Note:  There is a five minute delay until the first metrics will show up.


### PR DESCRIPTION
Removing the documentation for populate_redis.sh; this is no longer a requirement for running the docker.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
